### PR TITLE
Fix 2919 date typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ rds format:
 
 To create a cumulative report over a month use command:
 
-    pgbadger --month-report 2919-05 /path/to/incremantal/reports/
+    pgbadger --month-report 2019-05 /path/to/incremantal/reports/
 
 this will add a link to the month name into the calendar view in
 incremental reports to look at report for month 2019 May.
@@ -667,7 +667,7 @@ By default pgBadger in incremental mode only compute daily and weekly reports.
 If you want monthly cumulative reports you will have to use a separate command
 to specify the report to build. For example to build a report for August 2019:
 
-    pgbadger -X --month-report 2919-08 /var/www/pg_reports/
+    pgbadger -X --month-report 2019-08 /var/www/pg_reports/
 
 this will add a link to the month name into the calendar view of incremental
 reports to look at monthly report. The report for a current month can be run
@@ -677,7 +677,7 @@ default because it could take lot of time following the amount of data.
 If reports were built with the per database option ( -E | --explode ) it must
 be used too when calling pgbadger to build monthly report:
 
-    pgbadger -E -X --month-report 2919-08 /var/www/pg_reports/
+    pgbadger -E -X --month-report 2019-08 /var/www/pg_reports/
 
 This is the same when using the rebuild option ( -R | --rebuild ).
 


### PR DESCRIPTION
There were three dates in the examples that used "2919" instead of "2019", so I've fixed those.